### PR TITLE
docs: update README for .json format and fix grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-# PulseEffects Preset
+# PulseEffects Presets
 
-Preset files for the most rich audio effects library - [PulseEffects](https://github.com/wwmm/pulseeffects/)
+Preset files for [PulseEffects](https://github.com/wwmm/pulseeffects/), a powerful audio effects library for Linux.
 
-Preset Details:
+## Preset Details
 
-1. Tight Bass with vocals clarity - This preset focuses on enriching the base out of audio without compromising on clarity of vocals.
+1. **Tight Bass with Vocal Clarity** – This preset focuses on enriching the bass in your audio without compromising vocal clarity.
 
 ## Installation
 
-* Just copy the .preset files into the PulseEffects directory you can find in the local config directory. 
+* Copy the `.json` preset files into the PulseEffects directory within your local configuration directory.
 
-* Obviously the location of that directory depends on how you installed PulseEffects. 
+* The location of this directory depends on how you installed PulseEffects:
 
-* If you installed it through Flatpak, you can find it in ~/.var/app/com.github.wwmm.pulseeffects/config/PulseEffects, or if you used the PPA for Ubuntu (or the AUR package for Arch) it should be ~/.config/PulseEffects
+    * **Flatpak:** `~/.var/app/com.github.wwmm.pulseeffects/config/PulseEffects`
+    * **PPA (Ubuntu) or AUR (Arch):** `~/.config/PulseEffects`


### PR DESCRIPTION
Hi! I updated the README to clarify that newer PulseEffects versions use .json instead of .preset. I also improved some phrasing and grammar for better readability. Hope this helps!